### PR TITLE
Improve auth persistence and guard handling

### DIFF
--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -2,7 +2,9 @@
 
 $defaultOrigins = [
     'http://localhost:3000',
+    'http://localhost:5173',
     'http://127.0.0.1:3000',
+    'http://127.0.0.1:5173',
 ];
 
 $allowedOrigins = array_values(array_filter(array_map(

--- a/backend/config/sanctum.php
+++ b/backend/config/sanctum.php
@@ -5,7 +5,7 @@ use Laravel\Sanctum\Sanctum;
 return [
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
-        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        'localhost,localhost:3000,localhost:5173,127.0.0.1,127.0.0.1:8000,127.0.0.1:5173,::1',
         Sanctum::currentApplicationUrlWithPort()
     ))),
 

--- a/frontend/src/router/__tests__/authNavigationGuard.spec.js
+++ b/frontend/src/router/__tests__/authNavigationGuard.spec.js
@@ -1,0 +1,61 @@
+import { vi } from 'vitest'
+
+vi.mock('../../utils/notifications', () => ({
+    notifyError: vi.fn(),
+}))
+
+vi.mock('../../services/apiClient', () => ({
+    __esModule: true,
+    default: {
+        post: vi.fn(),
+    },
+}))
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { persistPlugin } from '../../stores/plugins/persist'
+import { useAuthStore } from '../../stores/auth'
+import apiClient from '../../services/apiClient'
+import { authNavigationGuard } from '../index'
+
+describe('authNavigationGuard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        window.localStorage.clear()
+        window.localStorage.setItem(
+            'predictive-patterns:auth',
+            JSON.stringify({
+                token: 'persisted-token',
+                user: { id: 1, role: 'user' },
+                hasRefreshSession: true,
+            })
+        )
+
+        const pinia = createPinia()
+        pinia.use(persistPlugin)
+        setActivePinia(pinia)
+    })
+
+    it('keeps dashboard accessible after session restore', async () => {
+        const auth = useAuthStore()
+        expect(auth.token).toBe('persisted-token')
+
+        apiClient.post.mockResolvedValueOnce({
+            data: {
+                accessToken: 'refreshed-token',
+                user: { id: 1, role: 'user' },
+            },
+        })
+
+        const result = await authNavigationGuard({
+            meta: { requiresAuth: true },
+            fullPath: '/dashboard',
+            path: '/dashboard',
+        })
+
+        expect(result).toBe(true)
+        expect(apiClient.post).toHaveBeenCalledWith('/auth/refresh')
+        expect(auth.token).toBe('refreshed-token')
+        expect(auth.isAuthenticated).toBe(true)
+    })
+})

--- a/frontend/src/stores/plugins/persist.js
+++ b/frontend/src/stores/plugins/persist.js
@@ -1,6 +1,7 @@
 const STORAGE_PREFIX = 'predictive-patterns'
 
 const allowList = {
+    auth: ['token', 'user', 'hasRefreshSession'],
     prediction: ['lastFilters'],
     map: ['selectedBaseLayer', 'heatmapOpacity', 'showHeatmap'],
 }


### PR DESCRIPTION
## Summary
- persist the auth token, user, and refresh capability in local storage so sessions survive reloads
- ensure the navigation guard awaits session restoration before routing and cover the flow with a dashboard access test
- add the Vite dev host ports to Sanctum and CORS defaults to prevent CSRF 419 responses during login