### PR TITLE
Handle failed logins with user feedback

### DIFF
--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -50,9 +50,17 @@ export const useAuthStore = defineStore('auth', () => {
             hasAttemptedRestore.value = true;
             await ensureCsrfCookie({ force: true, reason: 'login' });
 
-            return user.value;
+            return { success: true, user: user.value };
         } catch (error) {
-            setHasRefreshSession(false)
+            setHasRefreshSession(false);
+            hasAttemptedRestore.value = true;
+
+            const message =
+                error?.response?.data?.message ??
+                error?.message ??
+                'Unable to sign in. Please try again.';
+
+            return { success: false, error, message };
         }
     }
 

--- a/frontend/src/views/AuthView.vue
+++ b/frontend/src/views/AuthView.vue
@@ -35,9 +35,16 @@
                     class="rounded-xl border border-stone-300/80 px-4 py-3 text-sm shadow-sm shadow-stone-200/60 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                     name="password"
                     required
-                    type="password"
+                type="password"
                 />
             </label>
+            <p
+                v-if="loginError"
+                class="rounded-xl border border-red-300/80 bg-red-50 px-4 py-3 text-sm text-red-700"
+                role="alert"
+            >
+                {{ loginError }}
+            </p>
             <button
                 :disabled="submitting"
                 class="w-full rounded-xl bg-blue-600 px-4 py-3 text-sm font-semibold text-white shadow-sm shadow-blue-500/40 transition hover:bg-blue-700 focus-visible:outline  focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:bg-stone-400"
@@ -59,12 +66,22 @@ const router = useRouter()
 const email = ref('')
 const password = ref('')
 const submitting = ref(false)
+const loginError = ref('')
 
 async function submit() {
     submitting.value = true
+    loginError.value = ''
     try {
-        await authStore.login({ email: email.value, password: password.value })
+        const result = await authStore.login({ email: email.value, password: password.value })
+
+        if (result?.success === false) {
+            loginError.value = result.message ?? 'Unable to sign in. Please try again.'
+            return
+        }
+
         await router.push({ name: 'dashboard' });
+    } catch (error) {
+        loginError.value = error?.message ?? 'Unable to sign in. Please try again.'
     } finally {
         submitting.value = false
     }

--- a/frontend/src/views/__tests__/AuthView.spec.js
+++ b/frontend/src/views/__tests__/AuthView.spec.js
@@ -1,0 +1,40 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import AuthView from '../AuthView.vue'
+
+const push = vi.fn()
+const loginMock = vi.fn()
+
+vi.mock('vue-router', () => ({
+    useRouter: () => ({
+        push
+    })
+}))
+
+vi.mock('../../stores/auth', () => ({
+    useAuthStore: () => ({
+        login: loginMock
+    })
+}))
+
+describe('AuthView', () => {
+    beforeEach(() => {
+        loginMock.mockReset()
+        push.mockReset()
+    })
+
+    it('shows an accessible error when login fails', async () => {
+        loginMock.mockResolvedValue({ success: false, message: 'Invalid credentials' })
+
+        const wrapper = mount(AuthView)
+
+        await wrapper.find('input[name="email"]').setValue('user@example.com')
+        await wrapper.find('input[name="password"]').setValue('secret')
+        await wrapper.find('form').trigger('submit.prevent')
+        await flushPromises()
+
+        expect(loginMock).toHaveBeenCalledWith({ email: 'user@example.com', password: 'secret' })
+        expect(wrapper.get('[role="alert"]').text()).toContain('Invalid credentials')
+        expect(push).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Summary
- return a structured success/failure result from the auth store login action so callers can surface errors while keeping session flags in sync
- surface an accessible login failure alert in the authentication view and guard navigation when the attempt fails
- cover the failed-login path with a component test to ensure the error alert remains visible

## Testing
- npm exec vitest run -- --environment jsdom

------
https://chatgpt.com/codex/tasks/task_e_68e2a5b6cd988326b6fc96b79e990b54