### PR TITLE
Refactor dataset ingestion workflow into dedicated services

### DIFF
--- a/backend/app/Actions/DatasetIngestionAction.php
+++ b/backend/app/Actions/DatasetIngestionAction.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\DatasetStatus;
+use App\Events\DatasetStatusUpdated;
+use App\Http\Requests\DatasetIngestRequest;
+use App\Jobs\IngestRemoteDataset;
+use App\Models\Dataset;
+use App\Models\User;
+use App\Services\DatasetProcessingService;
+use App\Services\Datasets\SchemaMapper;
+use App\Support\Broadcasting\BroadcastDispatcher;
+use App\Support\Filesystem\CsvCombiner;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class DatasetIngestionAction
+{
+    public function __construct(
+        private readonly DatasetProcessingService $processingService,
+        private readonly SchemaMapper $schemaMapper,
+        private readonly CsvCombiner $csvCombiner,
+    ) {
+    }
+
+    public function execute(DatasetIngestRequest $request): Dataset
+    {
+        $validated = $request->validated();
+        $user = $request->user();
+        $createdBy = $user instanceof User ? $user->getKey() : null;
+        $schemaMapping = $this->schemaMapper->normalise($request->input('schema'));
+
+        $status = $validated['source_type'] === 'url'
+            ? DatasetStatus::Pending
+            : DatasetStatus::Processing;
+
+        $dataset = new Dataset([
+            'id' => (string) Str::uuid(),
+            'name' => $validated['name'],
+            'description' => $validated['description'] ?? null,
+            'source_type' => $validated['source_type'],
+            'source_uri' => $validated['source_uri'] ?? null,
+            'metadata' => $validated['metadata'] ?? [],
+            'status' => $status,
+            'created_by' => $createdBy,
+        ]);
+
+        if ($schemaMapping !== []) {
+            $dataset->schema_mapping = $schemaMapping;
+        }
+
+        $uploadedFiles = $this->collectUploadedFiles($request);
+
+        if ($uploadedFiles !== []) {
+            $this->storeUploadedFiles($dataset, $uploadedFiles);
+        }
+
+        $dataset->save();
+        $dataset->refresh();
+
+        $event = DatasetStatusUpdated::fromDataset($dataset);
+
+        BroadcastDispatcher::dispatch($event, [
+            'dataset_id' => $event->datasetId,
+            'status' => $event->status,
+        ]);
+
+        if ($dataset->source_type === 'url') {
+            IngestRemoteDataset::dispatch($dataset->id);
+
+            return $dataset;
+        }
+
+        $additionalMetadata = [];
+
+        if ($uploadedFiles !== []) {
+            $additionalMetadata = $this->buildSourceFilesMetadata($uploadedFiles);
+            $dataset->metadata = $this->processingService->mergeMetadata(
+                $dataset->metadata,
+                $additionalMetadata
+            );
+            $dataset->save();
+        }
+
+        $dataset = $this->processingService->queueFinalise($dataset, $schemaMapping, $additionalMetadata);
+
+        return $dataset;
+    }
+
+    /**
+     * @param array<int, UploadedFile> $files
+     */
+    private function buildSourceFilesMetadata(array $files): array
+    {
+        $names = [];
+
+        foreach ($files as $file) {
+            $name = $file->getClientOriginalName();
+
+            if (! is_string($name) || trim($name) === '') {
+                $name = $file->getFilename();
+            }
+
+            $names[] = (string) $name;
+        }
+
+        return [
+            'source_files' => $names,
+            'source_file_count' => count($names),
+        ];
+    }
+
+    /**
+     * @return array<int, UploadedFile>
+     */
+    private function collectUploadedFiles(DatasetIngestRequest $request): array
+    {
+        $files = Arr::wrap($request->file('files'));
+        $files = array_filter($files, static fn ($file) => $file instanceof UploadedFile);
+
+        if ($files === []) {
+            $single = $request->file('file');
+
+            if ($single instanceof UploadedFile) {
+                $files = [$single];
+            }
+        }
+
+        return array_values($files);
+    }
+
+    /**
+     * @param array<int, UploadedFile> $files
+     */
+    private function storeUploadedFiles(Dataset $dataset, array $files): void
+    {
+        if (count($files) === 1) {
+            $file = $files[0];
+            $fileName = sprintf('%s.%s', Str::uuid(), $file->getClientOriginalExtension());
+            $path = $file->storeAs('datasets', $fileName, 'local');
+
+            if ($path === false) {
+                throw new RuntimeException('Unable to store uploaded dataset file.');
+            }
+
+            $dataset->file_path = $path;
+            $dataset->mime_type = $file->getMimeType();
+            $dataset->checksum = hash_file('sha256', $file->getRealPath());
+
+            return;
+        }
+
+        [$path, $mimeType] = $this->csvCombiner->combine($files);
+        $dataset->file_path = $path;
+        $dataset->mime_type = $mimeType;
+        $dataset->checksum = hash_file('sha256', Storage::disk('local')->path($path));
+    }
+}

--- a/backend/app/Http/Controllers/Api/v1/DatasetController.php
+++ b/backend/app/Http/Controllers/Api/v1/DatasetController.php
@@ -2,8 +2,7 @@
 
 namespace App\Http\Controllers\Api\v1;
 
-use App\Enums\DatasetStatus;
-use App\Events\DatasetStatusUpdated;
+use App\Actions\DatasetIngestionAction;
 use App\Http\Requests\DatasetIndexRequest;
 use App\Http\Requests\DatasetIngestRequest;
 use App\Http\Requests\DatasetRunIndexRequest;
@@ -12,28 +11,19 @@ use App\Http\Resources\DatasetCollection;
 use App\Http\Resources\DatasetResource;
 use App\Models\CrimeIngestionRun;
 use App\Models\Dataset;
-use App\Models\User;
-use App\Jobs\IngestRemoteDataset;
 use App\Services\DatasetAnalysisService;
-use App\Services\DatasetProcessingService;
-use App\Support\Broadcasting\BroadcastDispatcher;
 use App\Support\InteractsWithPagination;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
-use RuntimeException;
 
 class DatasetController extends BaseController
 {
     use InteractsWithPagination;
 
     public function __construct(
-        private readonly DatasetProcessingService $processingService,
+        private readonly DatasetIngestionAction $ingestionAction,
         private readonly DatasetAnalysisService $analysisService,
     )
     {
@@ -122,79 +112,7 @@ class DatasetController extends BaseController
     {
         $this->authorize('create', Dataset::class);
 
-        $validated = $request->validated();
-        $user = $request->user();
-        $createdBy = $user instanceof User ? $user->getKey() : null;
-        $schemaMapping = $this->normaliseSchemaMapping($request->input('schema'));
-
-        $status = $validated['source_type'] === 'url'
-            ? DatasetStatus::Pending
-            : DatasetStatus::Processing;
-
-        $dataset = new Dataset([
-            'id' => (string) Str::uuid(),
-            'name' => $validated['name'],
-            'description' => $validated['description'] ?? null,
-            'source_type' => $validated['source_type'],
-            'source_uri' => $validated['source_uri'] ?? null,
-            'metadata' => $validated['metadata'] ?? [],
-            'status' => $status,
-            'created_by' => $createdBy,
-        ]);
-
-        if ($schemaMapping !== []) {
-            $dataset->schema_mapping = $schemaMapping;
-        }
-
-        $path = null;
-
-        $uploadedFiles = $this->collectUploadedFiles($request);
-
-        if ($uploadedFiles !== []) {
-            if (count($uploadedFiles) === 1) {
-                $file = $uploadedFiles[0];
-                $fileName = sprintf('%s.%s', Str::uuid(), $file->getClientOriginalExtension());
-                $path = $file->storeAs('datasets', $fileName, 'local');
-                $dataset->file_path = $path;
-                $dataset->mime_type = $file->getMimeType();
-                $dataset->checksum = hash_file('sha256', $file->getRealPath());
-            } else {
-                [$path, $mimeType] = $this->storeCombinedCsv($uploadedFiles);
-                $dataset->file_path = $path;
-                $dataset->mime_type = $mimeType;
-                $dataset->checksum = hash_file('sha256', Storage::disk('local')->path($path));
-                $dataset->metadata = $this->processingService->mergeMetadata(
-                    $dataset->metadata,
-                    $this->buildSourceFilesMetadata($uploadedFiles)
-                );
-            }
-        }
-
-        $dataset->save();
-        $dataset->refresh();
-
-        $event = DatasetStatusUpdated::fromDataset($dataset);
-        BroadcastDispatcher::dispatch($event, [
-            'dataset_id' => $event->datasetId,
-            'status' => $event->status,
-        ]);
-
-        if ($dataset->source_type === 'url') {
-            IngestRemoteDataset::dispatch($dataset->id);
-
-            if (DatasetResource::featuresTableExists()) {
-                $dataset->loadCount('features');
-            }
-
-            return $this->successResponse(
-                new DatasetResource($dataset),
-                Response::HTTP_CREATED
-            );
-        }
-
-        $dataset = $this->processingService->queueFinalise($dataset, $schemaMapping);
-
-        $dataset->refresh();
+        $dataset = $this->ingestionAction->execute($request);
 
         if (DatasetResource::featuresTableExists()) {
             $dataset->loadCount('features');
@@ -304,212 +222,4 @@ class DatasetController extends BaseController
     }
 
 
-    /**
-     * Builds metadata about the source files.
-     *
-     * @param array<int, UploadedFile> $files
-     *
-     * @return array{source_files: list<string>, source_file_count: int}
-     */
-    private function buildSourceFilesMetadata(array $files): array
-    {
-        $names = [];
-
-        foreach ($files as $file) {
-            $name = $file->getClientOriginalName();
-
-            if (! is_string($name) || trim($name) === '') {
-                $name = $file->getFilename();
-            }
-
-            $names[] = (string) $name;
-        }
-
-        return [
-            'source_files' => $names,
-            'source_file_count' => count($names),
-        ];
-    }
-
-    /**
-     * Normalises and validates the schema mapping input.
-     *
-     * @param mixed $schema
-     *
-     * @return array
-     */
-    private function normaliseSchemaMapping(mixed $schema): array
-    {
-        if (! is_array($schema)) {
-            return [];
-        }
-
-        $allowed = ['timestamp', 'latitude', 'longitude', 'category', 'risk', 'label'];
-        $normalised = [];
-
-        foreach ($allowed as $key) {
-            $value = $schema[$key] ?? null;
-
-            if (! is_string($value)) {
-                continue;
-            }
-
-            $value = trim($value);
-
-            if ($value === '') {
-                continue;
-            }
-
-            $normalised[$key] = $value;
-        }
-
-        foreach (['timestamp', 'latitude', 'longitude', 'category'] as $required) {
-            if (! array_key_exists($required, $normalised)) {
-                return [];
-            }
-        }
-
-        return $normalised;
-    }
-
-    /**
-     * Stores multiple uploaded CSV files as a single combined CSV file
-     *
-     * @param array<int, UploadedFile> $files
-     *
-     * @return array{0: string, 1: string}
-     */
-    private function storeCombinedCsv(array $files): array
-    {
-        $temporaryPath = tempnam(sys_get_temp_dir(), 'dataset-');
-
-        if ($temporaryPath === false) {
-            throw new RuntimeException('Unable to create temporary dataset file.');
-        }
-
-        $combinedHandle = fopen($temporaryPath, 'w+b');
-
-        if ($combinedHandle === false) {
-            throw new RuntimeException(sprintf('Unable to open temporary dataset file "%s" for writing.', $temporaryPath));
-        }
-
-        try {
-            foreach ($files as $index => $file) {
-                $handle = fopen($file->getRealPath(), 'rb');
-
-                if ($handle === false) {
-                    continue;
-                }
-
-                try {
-                    if ($index > 0) {
-                        $this->ensureTrailingNewline($combinedHandle);
-                        $this->discardFirstLine($handle);
-                    }
-
-                    stream_copy_to_stream($handle, $combinedHandle);
-                } finally {
-                    fclose($handle);
-                }
-            }
-        } finally {
-            fclose($combinedHandle);
-        }
-
-        $fileName = sprintf('%s.csv', Str::uuid());
-        $storagePath = 'datasets/' . $fileName;
-
-        $stream = fopen($temporaryPath, 'rb');
-
-        if ($stream === false) {
-            throw new RuntimeException(sprintf('Unable to read combined dataset file "%s".', $temporaryPath));
-        }
-
-        Storage::disk('local')->put($storagePath, $stream);
-        fclose($stream);
-
-        @unlink($temporaryPath);
-
-        return [$storagePath, 'text/csv'];
-    }
-
-    /**
-     * Collects uploaded files from the request.
-     *
-     * @return array<int, UploadedFile>
-     */
-    private function collectUploadedFiles(DatasetIngestRequest $request): array
-    {
-        $files = Arr::wrap($request->file('files'));
-        $files = array_filter($files, static fn ($file) => $file instanceof UploadedFile);
-
-        if ($files === []) {
-            $single = $request->file('file');
-
-            if ($single instanceof UploadedFile) {
-                $files = [$single];
-            }
-        }
-
-        return array_values($files);
-    }
-
-    /**
-     * Discards the first line from a file handle.
-     *
-     * @param resource $handle
-     */
-    private function discardFirstLine($handle): void
-    {
-        while (! feof($handle)) {
-            $character = fgetc($handle);
-
-            if ($character === false) {
-                break;
-            }
-
-            if ($character === "\n") {
-                break;
-            }
-
-            if ($character === "\r") {
-                $next = fgetc($handle);
-
-                if ($next !== "\n" && $next !== false) {
-                    fseek($handle, -1, SEEK_CUR);
-                }
-
-                break;
-            }
-        }
-    }
-
-    /**
-     * Ensures that a file handle ends with a newline character.
-     *
-     * @param resource $handle
-     */
-    private function ensureTrailingNewline($handle): void
-    {
-        fflush($handle);
-        $currentPosition = ftell($handle);
-
-        if ($currentPosition === false || $currentPosition === 0) {
-            return;
-        }
-
-        if (fseek($handle, -1, SEEK_END) !== 0) {
-            fseek($handle, 0, SEEK_END);
-
-            return;
-        }
-
-        $lastCharacter = fgetc($handle);
-
-        if ($lastCharacter !== "\n" && $lastCharacter !== "\r") {
-            fwrite($handle, PHP_EOL);
-        }
-
-        fseek($handle, 0, SEEK_END);
-    }
 }

--- a/backend/app/Services/DatasetProcessingService.php
+++ b/backend/app/Services/DatasetProcessingService.php
@@ -2,28 +2,25 @@
 
 namespace App\Services;
 
-use App\Enums\DatasetStatus;
 use App\Events\DatasetStatusUpdated;
 use App\Jobs\CompleteDatasetIngestion;
 use App\Models\Dataset;
-use App\Models\Feature;
+use App\Services\Datasets\DatasetRepository;
+use App\Services\Datasets\FeatureGenerator;
+use App\Services\Datasets\SchemaMapper;
 use App\Support\Broadcasting\BroadcastDispatcher;
-use Carbon\CarbonImmutable;
-use DateTimeImmutable;
-use App\Support\TimestampParser;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
-use JsonException;
 use Throwable;
 
 class DatasetProcessingService
 {
-    private ?bool $featuresTableExists = null;
-
-    public function __construct(private readonly DatasetPreviewService $previewService)
-    {
+    public function __construct(
+        private readonly DatasetPreviewService $previewService,
+        private readonly FeatureGenerator $featureGenerator,
+        private readonly SchemaMapper $schemaMapper,
+        private readonly DatasetRepository $datasetRepository,
+    ) {
     }
 
     /**
@@ -38,7 +35,7 @@ class DatasetProcessingService
     public function finalise(Dataset $dataset, array $schemaMapping = [], array $additionalMetadata = []): Dataset
     {
         if ($additionalMetadata !== []) {
-            $dataset->metadata = $this->mergeMetadata($dataset->metadata, $additionalMetadata);
+            $dataset->metadata = $this->datasetRepository->mergeMetadata($dataset->metadata, $additionalMetadata);
         }
 
         $preview = $this->generatePreview($dataset);
@@ -58,33 +55,29 @@ class DatasetProcessingService
 
             if ($schemaMapping !== []) {
                 $metadata['schema_mapping'] = $schemaMapping;
-                $metadata['derived_features'] = $this->buildDerivedFeaturesSummary(
+                $metadata['derived_features'] = $this->schemaMapper->summariseDerivedFeatures(
                     $schemaMapping,
                     $metadata['headers'] ?? [],
                     $metadata['preview_rows'] ?? []
                 );
             }
 
-            $dataset->metadata = $this->mergeMetadata($dataset->metadata, $metadata);
+            $dataset->metadata = $this->datasetRepository->mergeMetadata($dataset->metadata, $metadata);
         } elseif ($schemaMapping !== []) {
-            $dataset->metadata = $this->mergeMetadata($dataset->metadata, [
+            $dataset->metadata = $this->datasetRepository->mergeMetadata($dataset->metadata, [
                 'schema_mapping' => $schemaMapping,
-                'derived_features' => $this->buildDerivedFeaturesSummary($schemaMapping, [], []),
+                'derived_features' => $this->schemaMapper->summariseDerivedFeatures($schemaMapping, [], []),
             ]);
         }
 
-        $dataset->status = DatasetStatus::Ready;
-        $dataset->ingested_at = now();
-        $dataset->save();
+        $this->datasetRepository->markAsReady($dataset);
 
-        if ($schemaMapping !== [] && $dataset->file_path !== null) {
+        if ($schemaMapping !== [] && $dataset->file_path !== null && $this->datasetRepository->featuresTableExists()) {
             $dataset->refresh();
-            $this->populateFeaturesFromMapping($dataset, $schemaMapping);
+            $this->featureGenerator->populateFromMapping($dataset, $schemaMapping);
         }
 
-        if ($this->featuresTableExists()) {
-            $dataset->loadCount('features');
-        }
+        $this->datasetRepository->refreshFeatureCount($dataset);
 
         $event = DatasetStatusUpdated::fromDataset($dataset, 1.0);
         BroadcastDispatcher::dispatch($event, [
@@ -107,7 +100,7 @@ class DatasetProcessingService
     public function queueFinalise(Dataset $dataset, array $schemaMapping = [], array $additionalMetadata = []): Dataset
     {
         if ($additionalMetadata !== []) {
-            $dataset->metadata = $this->mergeMetadata($dataset->metadata, $additionalMetadata);
+            $dataset->metadata = $this->datasetRepository->mergeMetadata($dataset->metadata, $additionalMetadata);
             $dataset->save();
         }
 
@@ -131,23 +124,9 @@ class DatasetProcessingService
      */
     public function markAsFailed(Dataset $dataset, ?Throwable $exception = null): void
     {
-        $dataset->status = DatasetStatus::Failed;
-
-        $metadata = $this->mergeMetadata($dataset->metadata, [
-            'ingest_error' => $exception?->getMessage() ?: 'Dataset processing failed.',
-        ]);
-
-        $dataset->metadata = $metadata;
-        $dataset->ingested_at = null;
-        $dataset->save();
-
         $message = $exception?->getMessage() ?: 'Dataset processing failed.';
 
-        $event = DatasetStatusUpdated::fromDataset($dataset, 0.0, $message);
-        BroadcastDispatcher::dispatch($event, [
-            'dataset_id' => $event->datasetId,
-            'status' => $event->status,
-        ]);
+        $this->datasetRepository->markAsFailed($dataset, $message);
     }
 
     /**
@@ -160,512 +139,7 @@ class DatasetProcessingService
      */
     public function mergeMetadata(mixed $existing, array $additional): array
     {
-        $metadata = is_array($existing) ? $existing : [];
-
-        foreach ($additional as $key => $value) {
-            if (is_array($value) && $value === []) {
-                continue;
-            }
-
-            if ($value === null) {
-                continue;
-            }
-
-            $metadata[$key] = $value;
-        }
-
-        return $metadata;
-    }
-
-    /**
-     * Build a summary of derived features based on the provided schema mapping and preview rows.
-     *
-     * @param array<string, string> $schema
-     * @param list<string> $headers
-     * @param array<int, array<string, mixed>> $previewRows
-     *
-     * @return array<string, array<string, mixed>>
-     */
-    private function buildDerivedFeaturesSummary(array $schema, array $headers, array $previewRows): array
-    {
-        if ($schema === []) {
-            return [];
-        }
-
-        $summary = [];
-
-        foreach ($schema as $key => $column) {
-            if (! is_string($key) || ! is_string($column) || trim($column) === '') {
-                continue;
-            }
-
-            $sample = null;
-
-            foreach ($previewRows as $row) {
-                if (! is_array($row)) {
-                    continue;
-                }
-
-                if (! array_key_exists($column, $row)) {
-                    continue;
-                }
-
-                $value = $row[$column];
-
-                if ($value === null) {
-                    continue;
-                }
-
-                if (is_string($value) && trim($value) === '') {
-                    continue;
-                }
-
-                $sample = $value;
-                break;
-            }
-
-            $summary[$key] = ['column' => $column];
-
-            if ($sample !== null) {
-                $summary[$key]['sample'] = $sample;
-            }
-        }
-
-        return $summary;
-    }
-
-    /**
-     * Populate features for the dataset based on the provided schema mapping.
-     *
-     * @param Dataset $dataset
-     * @param array<string, string> $schema
-     */
-    private function populateFeaturesFromMapping(Dataset $dataset, array $schema): void
-    {
-        if (! $this->featuresTableExists()) {
-            return;
-        }
-
-        foreach (['timestamp', 'latitude', 'longitude', 'category'] as $requiredField) {
-            if (! array_key_exists($requiredField, $schema)) {
-                return;
-            }
-        }
-
-        $path = Storage::disk('local')->path($dataset->file_path);
-
-        if (! is_string($path) || ! is_file($path) || ! is_readable($path)) {
-            return;
-        }
-
-        Feature::query()->where('dataset_id', $dataset->getKey())->delete();
-
-        $index = 0;
-        $batch = [];
-        $batchSize = 500;
-        $timestamp = now()->toDateTimeString();
-
-        try {
-            foreach ($this->readDatasetRows($path, $dataset->mime_type) as $row) {
-                if (! is_array($row)) {
-                    continue;
-                }
-
-                $featureData = $this->buildFeatureFromRow($dataset, $schema, $row, $index);
-
-                if ($featureData === null) {
-                    continue;
-                }
-
-                $batch[] = $this->prepareFeatureForInsertion($dataset, $featureData, $timestamp);
-
-                if (count($batch) >= $batchSize) {
-                    $this->insertFeatureBatch($batch);
-                    $batch = [];
-                    $timestamp = now()->toDateTimeString();
-                }
-
-                $index++;
-            }
-
-            if ($batch !== []) {
-                $this->insertFeatureBatch($batch);
-            }
-        } catch (Throwable $exception) {
-            Log::warning('Failed to derive dataset features', [
-                'dataset_id' => $dataset->getKey(),
-                'error' => $exception->getMessage(),
-            ]);
-        }
-    }
-
-    /**
-     * Read dataset rows from the given file path based on its MIME type or extension.
-     *
-     * @param string $path
-     * @param string|null $mimeType
-     *
-     * @return iterable<array<string, mixed>>
-     */
-    private function readDatasetRows(string $path, ?string $mimeType): iterable
-    {
-        $mimeType = $mimeType !== null ? strtolower($mimeType) : null;
-
-        if ($mimeType !== null && str_contains($mimeType, 'json')) {
-            return [];
-        }
-
-        $extension = strtolower((string) pathinfo($path, PATHINFO_EXTENSION));
-
-        if (in_array($extension, ['json', 'geojson'], true)) {
-            return [];
-        }
-
-        return $this->readCsvRows($path);
-    }
-
-    /**
-     * Prepare a feature array for database insertion by adding necessary fields and encoding JSON attributes.
-     *
-     * @param Dataset $dataset
-     * @param string $timestamp
-     * @param array<string, mixed> $feature
-     *
-     * @return array<string, mixed>
-     * @throws JsonException
-     */
-    private function prepareFeatureForInsertion(Dataset $dataset, array $feature, string $timestamp): array
-    {
-        $feature['id'] = (string) Str::uuid();
-        $feature['dataset_id'] = $dataset->getKey();
-        $feature['created_at'] = $timestamp;
-        $feature['updated_at'] = $timestamp;
-
-        if (($feature['observed_at'] ?? null) instanceof CarbonImmutable) {
-            $feature['observed_at'] = $feature['observed_at']->toDateTimeString();
-        } elseif (isset($feature['observed_at']) && is_string($feature['observed_at'])) {
-            $feature['observed_at'] = trim($feature['observed_at']) !== ''
-                ? $feature['observed_at']
-                : null;
-        }
-
-        $feature['geometry'] = $this->encodeJsonAttribute($feature['geometry'] ?? null);
-        $feature['properties'] = $this->encodeJsonAttribute($feature['properties'] ?? null);
-
-        if (! array_key_exists('srid', $feature)) {
-            $feature['srid'] = 4326;
-        }
-
-        return $feature;
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $batch
-     */
-    private function insertFeatureBatch(array $batch): void
-    {
-        if ($batch === []) {
-            return;
-        }
-
-        Feature::query()->insert($batch);
-    }
-
-    /**
-     * Encode an array as a JSON string for storage in the database.
-     *
-     * @param array<string, mixed>|null $value
-     *
-     * @return string|null
-     * @throws JsonException
-     */
-    private function encodeJsonAttribute(?array $value): ?string
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        return json_encode(
-            $value,
-            JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_UNICODE
-        );
-    }
-
-    /**
-     * Read rows from a CSV file at the given path.
-     *
-     * @param string $path
-     *
-     * @return iterable<array<string, mixed>>
-     */
-    private function readCsvRows(string $path): iterable
-    {
-        $handle = fopen($path, 'rb');
-
-        if ($handle === false) {
-            return [];
-        }
-
-        try {
-            $headers = null;
-
-            while (($row = fgetcsv($handle)) !== false) {
-                if ($headers === null) {
-                    $headers = $this->normaliseCsvHeaders($row);
-
-                    if ($headers === []) {
-                        break;
-                    }
-
-                    continue;
-                }
-
-                if ($this->isEmptyCsvRow($row)) {
-                    continue;
-                }
-
-                $assoc = $this->combineCsvRow($headers, $row);
-
-                if ($assoc === null || $assoc === []) {
-                    continue;
-                }
-
-                yield $assoc;
-            }
-        } finally {
-            fclose($handle);
-        }
-    }
-
-    /**
-     * Build a feature array from a dataset row based on the provided schema mapping.
-     *
-     * @param array<string, string> $schema
-     * @param array<string, mixed> $row
-     *
-     * @return array<string, mixed>|null
-     */
-    private function buildFeatureFromRow(Dataset $dataset, array $schema, array $row, int $index): ?array
-    {
-        $latitudeKey = $schema['latitude'];
-        $longitudeKey = $schema['longitude'];
-        $timestampKey = $schema['timestamp'];
-        $categoryKey = $schema['category'];
-        $riskKey = $schema['risk'] ?? null;
-
-        if (! array_key_exists($latitudeKey, $row) || ! array_key_exists($longitudeKey, $row)) {
-            return null;
-        }
-
-        $latitude = $this->toFloat($row[$latitudeKey] ?? null);
-        $longitude = $this->toFloat($row[$longitudeKey] ?? null);
-
-        if ($latitude === null || $longitude === null) {
-            return null;
-        }
-
-        $observedAt = null;
-
-        if (array_key_exists($timestampKey, $row)) {
-            $observedAt = $this->parseTimestamp($row[$timestampKey]);
-        }
-
-        $category = $row[$categoryKey] ?? null;
-        $name = is_scalar($category) ? trim((string) $category) : '';
-
-        if ($name === '') {
-            $name = sprintf('Feature %d', $index + 1);
-        }
-
-        $properties = [
-            'latitude' => $latitude,
-            'longitude' => $longitude,
-        ];
-
-        if ($observedAt instanceof CarbonImmutable) {
-            $properties['timestamp'] = $observedAt->toIso8601String();
-        }
-
-        if (is_scalar($category) && trim((string) $category) !== '') {
-            $properties['category'] = (string) $category;
-        }
-
-        if ($riskKey !== null && array_key_exists($riskKey, $row)) {
-            $riskScore = $this->toFloat($row[$riskKey]);
-
-            if ($riskScore !== null) {
-                $properties['risk_score'] = $riskScore;
-            } elseif (is_scalar($row[$riskKey]) && trim((string) $row[$riskKey]) !== '') {
-                $properties['risk_score'] = $row[$riskKey];
-            }
-        }
-
-        $properties = array_filter($properties, static function ($value) {
-            if (is_string($value)) {
-                return trim($value) !== '';
-            }
-
-            return $value !== null;
-        });
-
-        return [
-            'dataset_id' => $dataset->getKey(),
-            'name' => $name,
-            'geometry' => [
-                'type' => 'Point',
-                'coordinates' => [$longitude, $latitude],
-            ],
-            'properties' => $properties,
-            'observed_at' => $observedAt,
-            'srid' => 4326,
-        ];
-    }
-
-    /**
-     * Parse a timestamp from various input formats into a DateTimeImmutable object.
-     *
-     * @param mixed $value
-     *
-     * @return DateTimeImmutable|null
-     */
-    private function parseTimestamp(mixed $value): ?DateTimeImmutable
-    {
-        return TimestampParser::parse($value);
-    }
-
-    /**
-     * Convert a value to a float if possible.
-     *
-     * @param mixed $value
-     *
-     * @return float|null
-     */
-    private function toFloat(mixed $value): ?float
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        if (is_float($value) || is_int($value)) {
-            return (float) $value;
-        }
-
-        if (is_string($value)) {
-            $numeric = trim($value);
-
-            if ($numeric === '') {
-                return null;
-            }
-
-            if (! is_numeric($numeric)) {
-                return null;
-            }
-
-            return (float) $numeric;
-        }
-
-        return null;
-    }
-
-    /**
-     * Normalise CSV headers by removing BOM characters and trimming whitespace.
-     *
-     * @param array<int, string|null> $headers
-     *
-     * @return list<string>
-     */
-    private function normaliseCsvHeaders(array $headers): array
-    {
-        $normalised = [];
-
-        foreach ($headers as $header) {
-            if ($header === null) {
-                $normalised[] = '';
-                continue;
-            }
-
-            $value = preg_replace('/^\xEF\xBB\xBF/', '', $header);
-            $value = trim((string) $value);
-
-            $normalised[] = $value;
-        }
-
-        return $normalised;
-    }
-
-    /**
-     * Check if a CSV row is empty (all values are null or empty strings).
-     *
-     * @param array<int, string|null> $row
-     *
-     * @return bool
-     */
-    private function isEmptyCsvRow(array $row): bool
-    {
-        foreach ($row as $value) {
-            if ($value === null) {
-                continue;
-            }
-
-            if (trim((string) $value) !== '') {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Combine CSV row values with headers to create an associative array.
-     *
-     * @param list<string> $headers
-     * @param array<int, string|null> $row
-     *
-     * @return array<string, string|null>|null
-     */
-    private function combineCsvRow(array $headers, array $row): ?array
-    {
-        if ($headers === []) {
-            return null;
-        }
-
-        $assoc = [];
-
-        foreach ($headers as $index => $header) {
-            if ($header === '') {
-                continue;
-            }
-
-            $value = $row[$index] ?? null;
-
-            if (is_string($value)) {
-                $value = trim($value);
-            }
-
-            $assoc[$header] = $value;
-        }
-
-        foreach ($assoc as $value) {
-            if ($value !== null && $value !== '') {
-                return $assoc;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Check if the 'features' table exists in the database.
-     *
-     * @return bool
-     */
-    private function featuresTableExists(): bool
-    {
-        if ($this->featuresTableExists !== null) {
-            return $this->featuresTableExists;
-        }
-
-        return $this->featuresTableExists = Schema::hasTable('features');
+        return $this->datasetRepository->mergeMetadata($existing, $additional);
     }
 
     /**

--- a/backend/app/Services/Datasets/CsvParser.php
+++ b/backend/app/Services/Datasets/CsvParser.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Services\Datasets;
+
+use Generator;
+
+class CsvParser
+{
+    /**
+     * Read dataset rows from the given file path based on its MIME type or extension.
+     *
+     * @param string $path
+     * @param string|null $mimeType
+     *
+     * @return iterable<array<string, mixed>>
+     */
+    public function readDatasetRows(string $path, ?string $mimeType): iterable
+    {
+        $mimeType = $mimeType !== null ? strtolower($mimeType) : null;
+
+        if ($mimeType !== null && str_contains($mimeType, 'json')) {
+            return [];
+        }
+
+        $extension = strtolower((string) pathinfo($path, PATHINFO_EXTENSION));
+
+        if (in_array($extension, ['json', 'geojson'], true)) {
+            return [];
+        }
+
+        return $this->readCsvRows($path);
+    }
+
+    /**
+     * Read rows from a CSV file at the given path.
+     *
+     * @param string $path
+     *
+     * @return iterable<array<string, mixed>>
+     */
+    public function readCsvRows(string $path): iterable
+    {
+        $handle = fopen($path, 'rb');
+
+        if ($handle === false) {
+            return [];
+        }
+
+        try {
+            $headers = null;
+
+            while (($row = fgetcsv($handle)) !== false) {
+                if ($headers === null) {
+                    $headers = $this->normaliseHeaders($row);
+
+                    if ($headers === []) {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                if ($this->isEmptyRow($row)) {
+                    continue;
+                }
+
+                $assoc = $this->combineRow($headers, $row);
+
+                if ($assoc === null || $assoc === []) {
+                    continue;
+                }
+
+                yield $assoc;
+            }
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    /**
+     * Normalise CSV headers by removing BOM characters and trimming whitespace.
+     *
+     * @param array<int, string|null> $headers
+     *
+     * @return list<string>
+     */
+    public function normaliseHeaders(array $headers): array
+    {
+        $normalised = [];
+
+        foreach ($headers as $header) {
+            if ($header === null) {
+                $normalised[] = '';
+                continue;
+            }
+
+            $value = preg_replace('/^\xEF\xBB\xBF/', '', $header);
+            $value = trim((string) $value);
+
+            $normalised[] = $value;
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * Check if a CSV row is empty (all values are null or empty strings).
+     *
+     * @param array<int, string|null> $row
+     */
+    public function isEmptyRow(array $row): bool
+    {
+        foreach ($row as $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            if (trim((string) $value) !== '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Combine CSV row values with headers to create an associative array.
+     *
+     * @param list<string> $headers
+     * @param array<int, string|null> $row
+     *
+     * @return array<string, string|null>|null
+     */
+    public function combineRow(array $headers, array $row): ?array
+    {
+        if ($headers === []) {
+            return null;
+        }
+
+        $assoc = [];
+
+        foreach ($headers as $index => $header) {
+            if ($header === '') {
+                continue;
+            }
+
+            $value = $row[$index] ?? null;
+
+            if (is_string($value)) {
+                $value = trim($value);
+            }
+
+            $assoc[$header] = $value;
+        }
+
+        foreach ($assoc as $value) {
+            if ($value !== null && $value !== '') {
+                return $assoc;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Datasets/DatasetRepository.php
+++ b/backend/app/Services/Datasets/DatasetRepository.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Services\Datasets;
+
+use App\Enums\DatasetStatus;
+use App\Events\DatasetStatusUpdated;
+use App\Models\Dataset;
+use App\Support\Broadcasting\BroadcastDispatcher;
+use Illuminate\Support\Facades\Schema;
+
+class DatasetRepository
+{
+    private ?bool $featuresTableExists = null;
+
+    /**
+     * Merge existing metadata with additional metadata, overriding existing keys with new values.
+     *
+     * @param mixed $existing
+     * @param array $additional
+     *
+     * @return array<string, mixed>
+     */
+    public function mergeMetadata(mixed $existing, array $additional): array
+    {
+        $metadata = is_array($existing) ? $existing : [];
+
+        foreach ($additional as $key => $value) {
+            if (is_array($value) && $value === []) {
+                continue;
+            }
+
+            if ($value === null) {
+                continue;
+            }
+
+            $metadata[$key] = $value;
+        }
+
+        return $metadata;
+    }
+
+    public function markAsReady(Dataset $dataset): void
+    {
+        $dataset->status = DatasetStatus::Ready;
+        $dataset->ingested_at = now();
+        $dataset->save();
+    }
+
+    public function markAsFailed(Dataset $dataset, string $message): void
+    {
+        $dataset->status = DatasetStatus::Failed;
+        $dataset->metadata = $this->mergeMetadata($dataset->metadata, [
+            'ingest_error' => $message,
+        ]);
+        $dataset->ingested_at = null;
+        $dataset->save();
+
+        $event = DatasetStatusUpdated::fromDataset($dataset, 0.0, $message);
+
+        BroadcastDispatcher::dispatch($event, [
+            'dataset_id' => $event->datasetId,
+            'status' => $event->status,
+        ]);
+    }
+
+    public function featuresTableExists(): bool
+    {
+        if ($this->featuresTableExists !== null) {
+            return $this->featuresTableExists;
+        }
+
+        return $this->featuresTableExists = Schema::hasTable('features');
+    }
+
+    public function refreshFeatureCount(Dataset $dataset): void
+    {
+        if (! $this->featuresTableExists()) {
+            return;
+        }
+
+        $dataset->loadCount('features');
+    }
+}

--- a/backend/app/Services/Datasets/FeatureGenerator.php
+++ b/backend/app/Services/Datasets/FeatureGenerator.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace App\Services\Datasets;
+
+use App\Models\Dataset;
+use App\Models\Feature;
+use App\Support\TimestampParser;
+use Carbon\CarbonImmutable;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use JsonException;
+use Throwable;
+
+class FeatureGenerator
+{
+    public function __construct(private readonly CsvParser $csvParser)
+    {
+    }
+
+    /**
+     * Populate features for the dataset based on the provided schema mapping.
+     *
+     * @param array<string, string> $schema
+     */
+    public function populateFromMapping(Dataset $dataset, array $schema): void
+    {
+        foreach (['timestamp', 'latitude', 'longitude', 'category'] as $requiredField) {
+            if (! array_key_exists($requiredField, $schema)) {
+                return;
+            }
+        }
+
+        $path = Storage::disk('local')->path($dataset->file_path);
+
+        if (! is_string($path) || ! is_file($path) || ! is_readable($path)) {
+            return;
+        }
+
+        Feature::query()->where('dataset_id', $dataset->getKey())->delete();
+
+        $index = 0;
+        $batch = [];
+        $batchSize = 500;
+        $timestamp = now()->toDateTimeString();
+
+        try {
+            foreach ($this->csvParser->readDatasetRows($path, $dataset->mime_type) as $row) {
+                if (! is_array($row)) {
+                    continue;
+                }
+
+                $featureData = $this->buildFeatureFromRow($dataset, $schema, $row, $index);
+
+                if ($featureData === null) {
+                    continue;
+                }
+
+                $batch[] = $this->prepareFeatureForInsertion($dataset, $featureData, $timestamp);
+
+                if (count($batch) >= $batchSize) {
+                    $this->insertFeatureBatch($batch);
+                    $batch = [];
+                    $timestamp = now()->toDateTimeString();
+                }
+
+                $index++;
+            }
+
+            if ($batch !== []) {
+                $this->insertFeatureBatch($batch);
+            }
+        } catch (Throwable $exception) {
+            Log::warning('Failed to derive dataset features', [
+                'dataset_id' => $dataset->getKey(),
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Build a feature array from a dataset row based on the provided schema mapping.
+     *
+     * @param array<string, string> $schema
+     * @param array<string, mixed> $row
+     */
+    public function buildFeatureFromRow(Dataset $dataset, array $schema, array $row, int $index): ?array
+    {
+        $latitudeKey = $schema['latitude'];
+        $longitudeKey = $schema['longitude'];
+        $timestampKey = $schema['timestamp'];
+        $categoryKey = $schema['category'];
+        $riskKey = $schema['risk'] ?? null;
+
+        if (! array_key_exists($latitudeKey, $row) || ! array_key_exists($longitudeKey, $row)) {
+            return null;
+        }
+
+        $latitude = $this->toFloat($row[$latitudeKey] ?? null);
+        $longitude = $this->toFloat($row[$longitudeKey] ?? null);
+
+        if ($latitude === null || $longitude === null) {
+            return null;
+        }
+
+        $observedAt = null;
+
+        if (array_key_exists($timestampKey, $row)) {
+            $observedAt = $this->parseTimestamp($row[$timestampKey]);
+        }
+
+        $category = $row[$categoryKey] ?? null;
+        $name = is_scalar($category) ? trim((string) $category) : '';
+
+        if ($name === '') {
+            $name = sprintf('Feature %d', $index + 1);
+        }
+
+        $properties = [
+            'latitude' => $latitude,
+            'longitude' => $longitude,
+        ];
+
+        if ($observedAt instanceof CarbonImmutable) {
+            $properties['timestamp'] = $observedAt->toIso8601String();
+        }
+
+        if (is_scalar($category) && trim((string) $category) !== '') {
+            $properties['category'] = (string) $category;
+        }
+
+        if ($riskKey !== null && array_key_exists($riskKey, $row)) {
+            $riskScore = $this->toFloat($row[$riskKey]);
+
+            if ($riskScore !== null) {
+                $properties['risk_score'] = $riskScore;
+            } elseif (is_scalar($row[$riskKey]) && trim((string) $row[$riskKey]) !== '') {
+                $properties['risk_score'] = $row[$riskKey];
+            }
+        }
+
+        $properties = array_filter($properties, static function ($value) {
+            if (is_string($value)) {
+                return trim($value) !== '';
+            }
+
+            return $value !== null;
+        });
+
+        return [
+            'dataset_id' => $dataset->getKey(),
+            'name' => $name,
+            'geometry' => [
+                'type' => 'Point',
+                'coordinates' => [$longitude, $latitude],
+            ],
+            'properties' => $properties,
+            'observed_at' => $observedAt,
+            'srid' => 4326,
+        ];
+    }
+
+    /**
+     * Prepare a feature array for database insertion by adding necessary fields and encoding JSON attributes.
+     *
+     * @param array<string, mixed> $feature
+     *
+     * @throws JsonException
+     */
+    public function prepareFeatureForInsertion(Dataset $dataset, array $feature, string $timestamp): array
+    {
+        $feature['id'] = (string) Str::uuid();
+        $feature['dataset_id'] = $dataset->getKey();
+        $feature['created_at'] = $timestamp;
+        $feature['updated_at'] = $timestamp;
+
+        if (($feature['observed_at'] ?? null) instanceof CarbonImmutable) {
+            $feature['observed_at'] = $feature['observed_at']->toDateTimeString();
+        } elseif (isset($feature['observed_at']) && is_string($feature['observed_at'])) {
+            $feature['observed_at'] = trim($feature['observed_at']) !== ''
+                ? $feature['observed_at']
+                : null;
+        }
+
+        $feature['geometry'] = $this->encodeJsonAttribute($feature['geometry'] ?? null);
+        $feature['properties'] = $this->encodeJsonAttribute($feature['properties'] ?? null);
+
+        if (! array_key_exists('srid', $feature)) {
+            $feature['srid'] = 4326;
+        }
+
+        return $feature;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $batch
+     */
+    private function insertFeatureBatch(array $batch): void
+    {
+        if ($batch === []) {
+            return;
+        }
+
+        Feature::query()->insert($batch);
+    }
+
+    /**
+     * Encode an array as a JSON string for storage in the database.
+     *
+     * @param array<string, mixed>|null $value
+     */
+    private function encodeJsonAttribute(?array $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return json_encode(
+            $value,
+            JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_UNICODE
+        );
+    }
+
+    private function parseTimestamp(mixed $value): ?DateTimeImmutable
+    {
+        return TimestampParser::parse($value);
+    }
+
+    private function toFloat(mixed $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_float($value) || is_int($value)) {
+            return (float) $value;
+        }
+
+        if (is_string($value)) {
+            $numeric = trim($value);
+
+            if ($numeric === '') {
+                return null;
+            }
+
+            if (! is_numeric($numeric)) {
+                return null;
+            }
+
+            return (float) $numeric;
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Datasets/SchemaMapper.php
+++ b/backend/app/Services/Datasets/SchemaMapper.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Services\Datasets;
+
+class SchemaMapper
+{
+    /**
+     * Normalises and validates the schema mapping input.
+     *
+     * @param mixed $schema
+     *
+     * @return array<string, string>
+     */
+    public function normalise(mixed $schema): array
+    {
+        if (! is_array($schema)) {
+            return [];
+        }
+
+        $allowed = ['timestamp', 'latitude', 'longitude', 'category', 'risk', 'label'];
+        $normalised = [];
+
+        foreach ($allowed as $key) {
+            $value = $schema[$key] ?? null;
+
+            if (! is_string($value)) {
+                continue;
+            }
+
+            $value = trim($value);
+
+            if ($value === '') {
+                continue;
+            }
+
+            $normalised[$key] = $value;
+        }
+
+        foreach (['timestamp', 'latitude', 'longitude', 'category'] as $required) {
+            if (! array_key_exists($required, $normalised)) {
+                return [];
+            }
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * Build a summary of derived features based on the provided schema mapping and preview rows.
+     *
+     * @param array<string, string> $schema
+     * @param list<string> $headers
+     * @param array<int, array<string, mixed>> $previewRows
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function summariseDerivedFeatures(array $schema, array $headers, array $previewRows): array
+    {
+        if ($schema === []) {
+            return [];
+        }
+
+        $summary = [];
+
+        foreach ($schema as $key => $column) {
+            if (! is_string($key) || ! is_string($column) || trim($column) === '') {
+                continue;
+            }
+
+            $sample = null;
+
+            foreach ($previewRows as $row) {
+                if (! is_array($row)) {
+                    continue;
+                }
+
+                if (! array_key_exists($column, $row)) {
+                    continue;
+                }
+
+                $value = $row[$column];
+
+                if ($value === null) {
+                    continue;
+                }
+
+                if (is_string($value) && trim($value) === '') {
+                    continue;
+                }
+
+                $sample = $value;
+                break;
+            }
+
+            $summary[$key] = ['column' => $column];
+
+            if ($sample !== null) {
+                $summary[$key]['sample'] = $sample;
+            }
+        }
+
+        return $summary;
+    }
+}

--- a/backend/app/Support/Filesystem/CsvCombiner.php
+++ b/backend/app/Support/Filesystem/CsvCombiner.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Support\Filesystem;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class CsvCombiner
+{
+    /**
+     * @param array<int, UploadedFile> $files
+     *
+     * @return array{0: string, 1: string}
+     */
+    public function combine(array $files): array
+    {
+        $temporaryPath = tempnam(sys_get_temp_dir(), 'dataset-');
+
+        if ($temporaryPath === false) {
+            throw new RuntimeException('Unable to create temporary dataset file.');
+        }
+
+        $combinedHandle = fopen($temporaryPath, 'w+b');
+
+        if ($combinedHandle === false) {
+            throw new RuntimeException(sprintf('Unable to open temporary dataset file "%s" for writing.', $temporaryPath));
+        }
+
+        try {
+            foreach ($files as $index => $file) {
+                $handle = fopen($file->getRealPath(), 'rb');
+
+                if ($handle === false) {
+                    continue;
+                }
+
+                try {
+                    if ($index > 0) {
+                        $this->ensureTrailingNewline($combinedHandle);
+                        $this->discardFirstLine($handle);
+                    }
+
+                    stream_copy_to_stream($handle, $combinedHandle);
+                } finally {
+                    fclose($handle);
+                }
+            }
+        } finally {
+            fclose($combinedHandle);
+        }
+
+        $fileName = sprintf('%s.csv', Str::uuid());
+        $storagePath = 'datasets/' . $fileName;
+
+        $stream = fopen($temporaryPath, 'rb');
+
+        if ($stream === false) {
+            throw new RuntimeException(sprintf('Unable to read combined dataset file "%s".', $temporaryPath));
+        }
+
+        Storage::disk('local')->put($storagePath, $stream);
+        fclose($stream);
+
+        @unlink($temporaryPath);
+
+        return [$storagePath, 'text/csv'];
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private function discardFirstLine($handle): void
+    {
+        while (! feof($handle)) {
+            $character = fgetc($handle);
+
+            if ($character === false) {
+                break;
+            }
+
+            if ($character === "\n") {
+                break;
+            }
+
+            if ($character === "\r") {
+                $next = fgetc($handle);
+
+                if ($next !== "\n" && $next !== false) {
+                    fseek($handle, -1, SEEK_CUR);
+                }
+
+                break;
+            }
+        }
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private function ensureTrailingNewline($handle): void
+    {
+        fflush($handle);
+        $currentPosition = ftell($handle);
+
+        if ($currentPosition === false || $currentPosition === 0) {
+            return;
+        }
+
+        if (fseek($handle, -1, SEEK_END) !== 0) {
+            fseek($handle, 0, SEEK_END);
+
+            return;
+        }
+
+        $lastCharacter = fgetc($handle);
+
+        if ($lastCharacter !== "\n" && $lastCharacter !== "\r") {
+            fwrite($handle, PHP_EOL);
+        }
+
+        fseek($handle, 0, SEEK_END);
+    }
+}

--- a/backend/docs/architecture/dataset-controller.md
+++ b/backend/docs/architecture/dataset-controller.md
@@ -1,0 +1,26 @@
+# DatasetController Responsibilities
+
+The `DatasetController` orchestrates read and ingest operations for datasets in the v1 API. It now delegates write-heavy behaviour to focused collaborators, which keeps the controller small and oriented around routing and policy checks.
+
+## Operations overview
+
+| Endpoint | Method | Description | Key dependencies |
+| --- | --- | --- | --- |
+| `index` | `GET /datasets` | Lists datasets with pagination, sorting and optional filters for status, source type and search terms. | `Dataset` Eloquent model, `DatasetResource` (feature count detection), `InteractsWithPagination` helper. |
+| `ingest` | `POST /datasets` | Validates and authorises ingestion requests, then delegates persistence and background processing to `DatasetIngestionAction`. Returns the created dataset resource. | `DatasetIngestionAction`, `DatasetResource` (feature count). |
+| `show` | `GET /datasets/{dataset}` | Presents a single dataset record with optional feature counts. | `Dataset` model binding, `DatasetResource`. |
+| `analysis` | `GET /datasets/{dataset}/analysis` | Provides summary analytics for a dataset. | `DatasetAnalysisService`. |
+| `runs` | `GET /dataset-runs` | Lists ingestion runs with filtering and sorting controls. | `CrimeIngestionRun` model, `DataIngestionCollection`. |
+
+## Dependency mapping
+
+- **Authorisation:** All methods rely on Laravel's policy layer (`authorize`) to enforce permissions on `Dataset` resources.
+- **Collections & resources:** `DatasetCollection`, `DatasetResource` and `DataIngestionCollection` transform model output for API responses.
+- **Domain services:**
+  - `DatasetIngestionAction` encapsulates dataset creation, file handling and queuing of ingestion workflows.
+  - `DatasetAnalysisService` computes aggregated analytics for the `analysis` endpoint.
+- **Supporting infrastructure:**
+  - `InteractsWithPagination` resolves pagination limits and sort directions from request input.
+  - Eloquent models (`Dataset`, `CrimeIngestionRun`) supply query scopes and persistence.
+
+The refactor isolates ingestion-specific behaviour inside `DatasetIngestionAction` (and the downstream processing services it calls), leaving the controller responsible for validation, authorisation and shaping HTTP responses.

--- a/backend/tests/Unit/Actions/DatasetIngestionActionTest.php
+++ b/backend/tests/Unit/Actions/DatasetIngestionActionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\DatasetIngestionAction;
+use App\Events\DatasetStatusUpdated;
+use App\Http\Requests\DatasetIngestRequest;
+use App\Models\User;
+use App\Services\DatasetProcessingService;
+use App\Services\Datasets\SchemaMapper;
+use App\Support\Filesystem\CsvCombiner;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+class DatasetIngestionActionTest extends TestCase
+{
+    use RefreshDatabase;
+    use MockeryPHPUnitIntegration;
+
+    public function test_execute_persists_dataset_and_dispatches_events(): void
+    {
+        Storage::fake('local');
+        Event::fake();
+
+        $processingService = Mockery::mock(DatasetProcessingService::class);
+        $processingService->shouldReceive('mergeMetadata')->never();
+        $processingService->shouldReceive('queueFinalise')
+            ->once()
+            ->andReturnUsing(function ($dataset, array $schema, array $metadata) {
+                $this->assertSame([], $schema);
+                $this->assertSame([], $metadata);
+
+                return $dataset;
+            });
+
+        $action = new DatasetIngestionAction(
+            $processingService,
+            new SchemaMapper(),
+            new CsvCombiner()
+        );
+
+        $user = User::factory()->create();
+        $file = UploadedFile::fake()->createWithContent('dataset.csv', "timestamp,latitude,longitude,category\n2024-01-01T00:00:00Z,51.5,-0.1,Robbery\n");
+
+        /** @var DatasetIngestRequest $request */
+        $request = DatasetIngestRequest::create('/datasets', 'POST', [
+            'name' => 'Test dataset',
+            'source_type' => 'file',
+        ], [], ['file' => $file]);
+        $request->setContainer(app());
+        $request->setLaravelSession(app('session')->driver());
+        $request->setUserResolver(fn () => $user);
+        $request->validateResolved();
+
+        $dataset = $action->execute($request);
+
+        $this->assertDatabaseHas('datasets', [
+            'id' => $dataset->id,
+            'name' => 'Test dataset',
+        ]);
+
+        Storage::disk('local')->assertExists($dataset->file_path);
+        Event::assertDispatched(DatasetStatusUpdated::class);
+    }
+}

--- a/backend/tests/Unit/Services/Datasets/CsvParserTest.php
+++ b/backend/tests/Unit/Services/Datasets/CsvParserTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Services\Datasets;
+
+use App\Services\Datasets\CsvParser;
+use PHPUnit\Framework\TestCase;
+
+class CsvParserTest extends TestCase
+{
+    private CsvParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->parser = new CsvParser();
+    }
+
+    public function test_normalise_headers_trims_values(): void
+    {
+        $headers = $this->parser->normaliseHeaders(["\xEF\xBB\xBF id ", null, ' name']);
+
+        $this->assertSame(['id', '', 'name'], $headers);
+    }
+
+    public function test_is_empty_row_detects_content(): void
+    {
+        $this->assertTrue($this->parser->isEmptyRow(['', null]));
+        $this->assertFalse($this->parser->isEmptyRow(['', 'value']));
+    }
+
+    public function test_combine_row_discards_blank_columns(): void
+    {
+        $row = $this->parser->combineRow(['id', '', 'name'], ['1', 'skip', 'Alice']);
+
+        $this->assertSame(['id' => '1', 'name' => 'Alice'], $row);
+    }
+
+    public function test_read_csv_rows_streams_associative_rows(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'csv-parser-');
+        file_put_contents($path, "id,name\n1,Alice\n2,Bob\n");
+
+        $rows = iterator_to_array($this->parser->readCsvRows($path));
+
+        unlink($path);
+
+        $this->assertSame([
+            ['id' => '1', 'name' => 'Alice'],
+            ['id' => '2', 'name' => 'Bob'],
+        ], $rows);
+    }
+}

--- a/backend/tests/Unit/Services/Datasets/DatasetRepositoryTest.php
+++ b/backend/tests/Unit/Services/Datasets/DatasetRepositoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Unit\Services\Datasets;
+
+use App\Enums\DatasetStatus;
+use App\Events\DatasetStatusUpdated;
+use App\Models\Dataset;
+use App\Services\Datasets\DatasetRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class DatasetRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private DatasetRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = new DatasetRepository();
+    }
+
+    public function test_merge_metadata_overrides_values_and_skips_nulls(): void
+    {
+        $metadata = $this->repository->mergeMetadata(['keep' => 'value'], [
+            'keep' => 'override',
+            'skip_null' => null,
+            'skip_empty' => [],
+        ]);
+
+        $this->assertSame(['keep' => 'override'], $metadata);
+    }
+
+    public function test_mark_as_failed_updates_status_and_dispatches_event(): void
+    {
+        Event::fake();
+
+        $dataset = Dataset::factory()->create([
+            'status' => DatasetStatus::Processing,
+            'metadata' => [],
+        ]);
+
+        $this->repository->markAsFailed($dataset, 'boom');
+
+        $dataset->refresh();
+
+        $this->assertSame(DatasetStatus::Failed, $dataset->status);
+        $this->assertSame('boom', $dataset->metadata['ingest_error']);
+
+        Event::assertDispatched(DatasetStatusUpdated::class, function (DatasetStatusUpdated $event) use ($dataset) {
+            return $event->datasetId === $dataset->id && $event->status === DatasetStatus::Failed;
+        });
+    }
+
+    public function test_features_table_exists_returns_boolean(): void
+    {
+        $this->assertTrue($this->repository->featuresTableExists());
+    }
+}

--- a/backend/tests/Unit/Services/Datasets/FeatureGeneratorTest.php
+++ b/backend/tests/Unit/Services/Datasets/FeatureGeneratorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Services\Datasets;
+
+use App\Enums\DatasetStatus;
+use App\Models\Dataset;
+use App\Services\Datasets\CsvParser;
+use App\Services\Datasets\FeatureGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class FeatureGeneratorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private FeatureGenerator $generator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->generator = new FeatureGenerator(new CsvParser());
+    }
+
+    public function test_build_feature_from_row_generates_geometry_and_properties(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $feature = $this->generator->buildFeatureFromRow($dataset, [
+            'timestamp' => 'observed_at',
+            'latitude' => 'lat',
+            'longitude' => 'lng',
+            'category' => 'type',
+        ], [
+            'observed_at' => '2024-01-01T00:00:00Z',
+            'lat' => '51.5',
+            'lng' => '-0.1',
+            'type' => 'Robbery',
+        ], 0);
+
+        $this->assertNotNull($feature);
+        $this->assertSame('Robbery', $feature['name']);
+        $this->assertSame([-0.1, 51.5], $feature['geometry']['coordinates']);
+        $this->assertArrayHasKey('timestamp', $feature['properties']);
+    }
+
+    public function test_populate_from_mapping_writes_features_to_database(): void
+    {
+        Storage::fake('local');
+
+        $csv = "timestamp,latitude,longitude,category\n2024-01-01T00:00:00Z,51.5,-0.1,Robbery\n";
+        Storage::disk('local')->put('datasets/test.csv', $csv);
+
+        $dataset = Dataset::factory()->create([
+            'status' => DatasetStatus::Processing,
+            'file_path' => 'datasets/test.csv',
+            'mime_type' => 'text/csv',
+        ]);
+
+        $this->generator->populateFromMapping($dataset, [
+            'timestamp' => 'timestamp',
+            'latitude' => 'latitude',
+            'longitude' => 'longitude',
+            'category' => 'category',
+        ]);
+
+        $this->assertDatabaseHas('features', [
+            'dataset_id' => $dataset->id,
+            'name' => 'Robbery',
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/Datasets/SchemaMapperTest.php
+++ b/backend/tests/Unit/Services/Datasets/SchemaMapperTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Services\Datasets;
+
+use App\Services\Datasets\SchemaMapper;
+use PHPUnit\Framework\TestCase;
+
+class SchemaMapperTest extends TestCase
+{
+    private SchemaMapper $mapper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mapper = new SchemaMapper();
+    }
+
+    public function test_normalise_filters_and_requires_columns(): void
+    {
+        $normalised = $this->mapper->normalise([
+            'timestamp' => ' observed_at ',
+            'latitude' => 'lat',
+            'longitude' => 'lng',
+            'category' => ' type ',
+            'risk' => '',
+            'invalid' => 'ignored',
+        ]);
+
+        $this->assertSame([
+            'timestamp' => 'observed_at',
+            'latitude' => 'lat',
+            'longitude' => 'lng',
+            'category' => 'type',
+        ], $normalised);
+    }
+
+    public function test_normalise_returns_empty_when_required_missing(): void
+    {
+        $this->assertSame([], $this->mapper->normalise([
+            'timestamp' => 'observed_at',
+            'latitude' => 'lat',
+        ]));
+    }
+
+    public function test_summarise_derived_features_extracts_samples(): void
+    {
+        $summary = $this->mapper->summariseDerivedFeatures([
+            'timestamp' => 'observed_at',
+            'category' => 'type',
+        ], ['observed_at', 'type'], [
+            ['observed_at' => '2024-01-01T00:00:00Z', 'type' => 'Robbery'],
+        ]);
+
+        $this->assertSame([
+            'timestamp' => [
+                'column' => 'observed_at',
+                'sample' => '2024-01-01T00:00:00Z',
+            ],
+            'category' => [
+                'column' => 'type',
+                'sample' => 'Robbery',
+            ],
+        ], $summary);
+    }
+}

--- a/backend/tests/Unit/Support/Filesystem/CsvCombinerTest.php
+++ b/backend/tests/Unit/Support/Filesystem/CsvCombinerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Support\Filesystem;
+
+use App\Support\Filesystem\CsvCombiner;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class CsvCombinerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+    }
+
+    public function test_combine_merges_multiple_csv_files(): void
+    {
+        $combiner = new CsvCombiner();
+
+        $first = UploadedFile::fake()->createWithContent('first.csv', "id,name\n1,Alice\n");
+        $second = UploadedFile::fake()->createWithContent('second.csv', "id,name\n2,Bob\n");
+
+        [$path, $mime] = $combiner->combine([$first, $second]);
+
+        $this->assertSame('text/csv', $mime);
+        Storage::disk('local')->assertExists($path);
+
+        $combined = Storage::disk('local')->get($path);
+
+        $this->assertStringContainsString("1,Alice", $combined);
+        $this->assertStringContainsString("2,Bob", $combined);
+        $this->assertSame(1, substr_count($combined, 'id,name'));
+    }
+}


### PR DESCRIPTION
## Summary
- extract dataset ingestion logic into a dedicated action and CSV combiner so the API controller only orchestrates requests
- split the dataset processing service into SchemaMapper, CsvParser, FeatureGenerator and DatasetRepository collaborators
- add architecture notes plus unit tests that exercise the new ingestion and processing components