### PR TITLE
Improve aggregation cache invalidation and dataset ingestion streaming

### DIFF
--- a/backend/app/Services/PoliceCrimeIngestionService.php
+++ b/backend/app/Services/PoliceCrimeIngestionService.php
@@ -620,7 +620,7 @@ class PoliceCrimeIngestionService
 
         if (!$dryRun && $insertable > 0) {
             Crime::query()->insert($buffer);
-            $this->h3AggregationService->bumpCacheVersion();
+            $this->h3AggregationService->invalidateAggregatesForRecords($buffer);
         }
 
         $buffer = [];

--- a/backend/database/migrations/2025_10_03_230000_add_crime_query_indexes.php
+++ b/backend/database/migrations/2025_10_03_230000_add_crime_query_indexes.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('crimes', function (Blueprint $table): void {
+            $table->index(['lat', 'lng'], 'crimes_lat_lng_index');
+            $table->index(['occurred_at', 'lat', 'lng'], 'crimes_occurred_lat_lng_index');
+            $table->index(['category', 'occurred_at'], 'crimes_category_occurred_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('crimes', function (Blueprint $table): void {
+            $table->dropIndex('crimes_lat_lng_index');
+            $table->dropIndex('crimes_occurred_lat_lng_index');
+            $table->dropIndex('crimes_category_occurred_index');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add cache tagging and explicit version helpers to the H3 aggregation service and flush affected caches after crime ingestion
- update heatmap tile caching to honour the shared tags/version and keep results in sync with aggregate data
- stream dataset CSV processing with LazyCollection chunking and add supporting crime query indexes for bounding-box filters