### PR TITLE
chore: add quality baseline and ci gates

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,9 @@
+- name: baseline
+  color: 0a84ff
+  description: Establish foundational tooling and quality gates
+- name: ci
+  color: 5856d6
+  description: Changes affecting continuous integration workflows
+- name: quality
+  color: 34c759
+  description: Improvements to linting, testing, or static analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  backend:
+    name: Backend Quality Gate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, pcov, sqlite3
+          coverage: pcov
+          ini-values: pcov.directory=backend
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ../.nvmrc
+
+      - name: Install Composer dependencies
+        run: |
+          composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Node dependencies
+        run: npm install
+
+      - name: Node audit (backend)
+        run: npm audit --audit-level=high
+
+      - name: Composer audit
+        run: composer audit --locked --no-interaction
+
+      - name: Laravel Pint
+        run: ./vendor/bin/pint --test
+
+      - name: Larastan
+        run: ./vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress
+
+      - name: Pest
+        env:
+          XDEBUG_MODE: coverage
+        run: ./vendor/bin/pest --coverage
+
+      - name: Rector dry run
+        run: ./vendor/bin/rector process --dry-run
+
+  frontend:
+    name: Frontend Quality Gate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ../.nvmrc
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Node audit (high severity)
+        run: npm audit --audit-level=high
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Vitest
+        run: npm run test:unit
+
+      - name: Playwright
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.idea/
 /frontend/node_modules/
+/frontend/playwright-report/
+/frontend/test-results/
 /backend/vendor/
 /.DS_Store
 /logs/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -17,6 +17,8 @@
 /public/hot
 /public/storage
 /storage/*.key
+/storage/coverage
+/storage/coverage.txt
 /storage/pail
 /vendor
 Homestead.json

--- a/backend/README.md
+++ b/backend/README.md
@@ -49,6 +49,20 @@ Run the automated test suite:
 php artisan test
 ```
 
+### Quality tooling
+
+Common quality gates can be executed locally via Composer scripts:
+
+```bash
+composer update       # Install the QA toolchain defined in require-dev
+composer lint        # Laravel Pint (PSR-12)
+composer analyse     # Larastan at level 6
+composer test:pest   # Pest with code coverage
+composer rector      # Rector dry run using Laravel 12 sets
+```
+
+Generate type-safe refactors in small batches with Rector’s incremental cache at `storage/framework/rector` to keep feedback loops snappy.
+
 ## Available commands
 
 | Command | Description |

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -3,7 +3,10 @@
     "name": "laravel/laravel",
     "type": "project",
     "description": "The skeleton application for the Laravel framework.",
-    "keywords": ["laravel", "framework"],
+    "keywords": [
+        "laravel",
+        "framework"
+    ],
     "license": "MIT",
     "require": {
         "php": "^8.2",
@@ -20,7 +23,12 @@
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
-        "phpunit/phpunit": "^11.5.3"
+        "nunomaduro/larastan": "^2.9",
+        "pestphp/pest": "^3.3",
+        "pestphp/pest-plugin-laravel": "^2.5",
+        "phpunit/phpunit": "^11.5.3",
+        "rector/rector": "^1.4",
+        "rector/rector-laravel": "^0.21"
     },
     "autoload": {
         "psr-4": {
@@ -52,6 +60,21 @@
         ],
         "pre-package-uninstall": [
             "Illuminate\\Foundation\\ComposerScripts::prePackageUninstall"
+        ],
+        "analyse": [
+            "@php ./vendor/bin/phpstan analyse --configuration=phpstan.neon"
+        ],
+        "lint": [
+            "@php ./vendor/bin/pint --test"
+        ],
+        "lint:fix": [
+            "@php ./vendor/bin/pint"
+        ],
+        "rector": [
+            "@php ./vendor/bin/rector process --dry-run"
+        ],
+        "test:pest": [
+            "@php ./vendor/bin/pest --coverage"
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",

--- a/backend/phpstan.neon
+++ b/backend/phpstan.neon
@@ -1,0 +1,2 @@
+includes:
+    - phpstan.neon.dist

--- a/backend/phpstan.neon.dist
+++ b/backend/phpstan.neon.dist
@@ -1,0 +1,20 @@
+includes:
+    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/nunomaduro/larastan/rules.neon
+
+parameters:
+    paths:
+        - app
+        - bootstrap/app.php
+        - config
+        - database
+    level: 6
+    tmpDir: storage/framework/phpstan
+    checkMissingIterableValueType: false
+    checkMissingVarReturnType: false
+    parallel:
+        maximumNumberOfProcesses: 4
+    ignoreErrors:
+        - '#Offset .+ does not exist on array#'
+    bootstrapFiles:
+        - bootstrap/app.php

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -12,6 +12,15 @@
             <directory>tests/Feature</directory>
         </testsuite>
     </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory>app</directory>
+        </include>
+        <report>
+            <html outputDirectory="storage/coverage"/>
+            <text outputFile="storage/coverage.txt" showUncoveredFiles="true"/>
+        </report>
+    </coverage>
     <source>
         <include>
             <directory>app</directory>

--- a/backend/pint.json
+++ b/backend/pint.json
@@ -1,0 +1,7 @@
+{
+    "preset": "psr12",
+    "exclude": [
+        "bootstrap/cache",
+        "storage"
+    ]
+}

--- a/backend/rector.php
+++ b/backend/rector.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Laravel\Set\LaravelSetList;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/app',
+        __DIR__ . '/database',
+        __DIR__ . '/routes',
+        __DIR__ . '/tests',
+    ]);
+
+    $rectorConfig->cacheDirectory(__DIR__ . '/storage/framework/rector');
+    $rectorConfig->phpVersion(80200);
+    $rectorConfig->importNames();
+    $rectorConfig->parallel();
+
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_82,
+        LaravelSetList::LARAVEL_120,
+    ]);
+
+    $rectorConfig->skip([
+        ReadOnlyPropertyRector::class => [__DIR__ . '/database'],
+    ]);
+};

--- a/backend/tests/Pest.php
+++ b/backend/tests/Pest.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\TestCase;
+
+uses(TestCase::class)->in(__DIR__ . '/Feature', __DIR__ . '/Unit');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --host",
-    "lint": "eslint . --ext .js,.vue"
+    "lint": "eslint . --ext .js,.vue",
+    "typecheck": "vue-tsc --noEmit",
+    "test:unit": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "axios": "^1.7.9",
@@ -22,18 +25,23 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@playwright/test": "^1.50.0",
     "@tailwindcss/vite": "^4.1.13",
     "@types/d": "^1.0.4",
     "@types/leaflet": "^1.9.20",
     "@vitejs/plugin-vue": "^6.0.1",
+    "@vitest/coverage-v8": "^3.2.4",
     "@vue/test-utils": "^2.4.3",
+    "@vue/tsconfig": "^1.0.4",
     "eslint": "^9.17.0",
     "eslint-plugin-vue": "^9.32.0",
     "globals": "^15.14.0",
     "jsdom": "^24.0.0",
     "rollup": "4.22.4",
     "tailwindcss": "^4.1.13",
+    "typescript": "^5.6.3",
     "vite": "^7.1.5",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vue-tsc": "^2.1.6"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { outputFolder: 'playwright-report' }]] : 'list',
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:3000',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: 'npm run dev',
+        port: 3000,
+        reuseExistingServer: !process.env.CI,
+      },
+})

--- a/frontend/tests/e2e/example.spec.ts
+++ b/frontend/tests/e2e/example.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Smoke test', () => {
+  test('loads landing page', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveTitle(/Predictive/i)
+  })
+})

--- a/frontend/tests/setup.js
+++ b/frontend/tests/setup.js
@@ -1,0 +1,3 @@
+import { expect } from 'vitest'
+
+expect.extend({})

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "allowJs": true,
+    "checkJs": false,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "types": [
+      "vitest",
+      "vite/client",
+      "@playwright/test"
+    ]
+  },
+  "include": [
+    "env.d.ts",
+    "src/**/*",
+    "tests/**/*",
+    "playwright.config.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -32,5 +32,9 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./tests/setup.js'],
     restoreMocks: true,
+    coverage: {
+      provider: 'v8',
+      reports: ['text', 'lcov'],
+    },
   },
 })


### PR DESCRIPTION
## Summary
- add Larastan, Pest, Rector, and Pint configuration to establish a PHP quality baseline with PSR-12 formatting and coverage-ready PHPUnit settings
- wire a full GitHub Actions pipeline that runs composer audit, Pint, Larastan, Pest with coverage, Rector dry runs, and the frontend’s lint, typecheck, Vitest, and Playwright suites
- enrich the frontend toolchain with Vitest coverage, Playwright smoke tests, TypeScript config, and shared labels/documentation for the new quality workflow